### PR TITLE
implement debug_output feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,8 @@ rustc_version = "0.3"
 
 [dev-dependencies]
 test_dep = {path="tests/test_dep"}
+
+[features]
+# writes epilouge!() result to a file and include!() it, instead of returning hygenic token streams. This makes
+# debugging faulty results easier.
+debug_output = ["lockjaw_processor/debug_output"]

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -22,7 +22,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-lockjaw = {path = "../"}
 printer = {path = "printer"}
 printer_impl = {path = "printer/printer_impl" }
 
@@ -31,3 +30,7 @@ lockjaw = {path = "../"}
 
 [dev-dependencies]
 printer_test = {path = "printer/printer_test" }
+
+[dependencies.lockjaw]
+path = "../"
+features = ["debug_output"]

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 use lockjaw::{component, component_module_manifest, injectable, module, module_impl, MaybeScoped};
-use std::ops::Deref;
 
 #[injectable]
 pub struct Greeter<'a> {
@@ -74,7 +73,7 @@ fn test_greeter() {
     component.greeter().greet();
 
     assert_eq!(
-        component.test_printer().get_messages().deref()[..],
+        component.test_printer().get_messages()[..],
         vec!["helloworld".to_owned()][..]
     );
 }

--- a/processor/Cargo.toml
+++ b/processor/Cargo.toml
@@ -31,6 +31,7 @@ proc-macro = true
 [features]
 default = []
 proto_generation = ["protoc-rust", "protoc-bin-vendored"]
+debug_output = []
 
 [dependencies]
 quote = "1.0"
@@ -39,7 +40,6 @@ proc-macro2 = "1.0.24"
 regex = "1"
 lazy_static = "1"
 backtrace = "0.3.55"
-
 [dependencies.syn]
 version = "1.0"
 features = ["full","extra-traits"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ use std::ops::Deref;
 ///     let component: Box<dyn MyComponent> = MyComponent::new();
 ///     let foo : Foo = component.foo();
 /// }
-/// epilogue!();
+/// private_test_epilogue!();
 /// ```
 ///
 /// # Creating injected types
@@ -71,7 +71,7 @@ use std::ops::Deref;
 /// }
 ///
 /// # fn main(){}
-/// # epilogue!();
+/// # private_test_epilogue!();
 /// ```
 /// # Installing modules
 /// Each component can install their separate set of [`modules`](module) to form a different
@@ -113,7 +113,7 @@ use std::ops::Deref;
 /// }
 ///
 /// # fn main() {}
-/// # epilogue!();
+/// # private_test_epilogue!();
 /// ```
 ///
 /// Component can select different modules providing the same type to change the behavior of types
@@ -170,7 +170,7 @@ use std::ops::Deref;
 ///     let other_component: Box<dyn OtherComponent> = OtherComponent::new();
 ///     assert_eq!(other_component.foo().string, "other_string");
 /// }
-/// epilogue!();
+/// private_test_epilogue!();
 /// ```
 ///
 /// # Creating component instances
@@ -213,7 +213,7 @@ use std::ops::Deref;
 ///
 ///     assert_eq!(component.string(), "foo");  
 /// }
-/// epilogue!();
+/// private_test_epilogue!();
 /// ```
 ///
 /// If a field is not attributed with `#[builder]`, lockjaw will auto generated it when building the
@@ -254,7 +254,7 @@ use std::ops::Deref;
 ///
 ///     assert_eq!(component.int(), 42);  
 /// }
-/// epilogue!();
+/// private_test_epilogue!();
 /// ```
 ///
 /// Lockjaw also generates `COMPONENT::new() -> Box<dyn COMPONENT>` if the component does not
@@ -271,7 +271,7 @@ use std::ops::Deref;
 /// pub fn main() {
 ///     let component: Box<dyn MyComponent> = MyComponent::new();
 /// }
-/// epilogue!();
+/// private_test_epilogue!();
 /// ```
 ///
 /// Each instance of the component will have independent set of [scoped injections](docs::scoped)


### PR DESCRIPTION
writes epilouge!() result to a file and include!() it, instead of returning hygenic token streams. This makes
debugging faulty results easier.