### PR TITLE
Revert "handle mut (#26)"

### DIFF
--- a/example/printer/printer_impl/src/lib.rs
+++ b/example/printer/printer_impl/src/lib.rs
@@ -21,7 +21,7 @@ use printer::Printer;
 pub struct PrinterImpl {}
 
 impl Printer for PrinterImpl {
-    fn print(&mut self, message: &str) {
+    fn print(&self, message: &str) {
         println!("{}", message);
     }
 }

--- a/example/printer/printer_test/src/lib.rs
+++ b/example/printer/printer_test/src/lib.rs
@@ -16,21 +16,22 @@ limitations under the License.
 
 use lockjaw::{epilogue, injectable, module, module_impl};
 use printer::Printer;
+use std::cell::Ref;
 
 #[injectable(scope = "::example::TestComponent")]
 pub struct TestPrinter {
-    pub messages: Vec<String>,
+    pub messages: ::std::cell::RefCell<Vec<String>>,
 }
 
 impl TestPrinter {
-    pub fn get_messages(&self) -> &Vec<String> {
-        &self.messages
+    pub fn get_messages(&self) -> Ref<Vec<String>> {
+        self.messages.borrow()
     }
 }
 
 impl Printer for TestPrinter {
-    fn print(&mut self, message: &str) {
-        self.messages.push(message.to_owned())
+    fn print(&self, message: &str) {
+        self.messages.borrow_mut().push(message.to_owned())
     }
 }
 
@@ -40,7 +41,7 @@ pub struct Module {}
 #[module_impl]
 impl Module {
     #[binds]
-    pub fn bind_printer(_impl: crate::TestPrinter) -> impl ::printer::Printer {}
+    pub fn bind_printer(_impl: &crate::TestPrinter) -> impl ::printer::Printer {}
 }
 
 epilogue!();

--- a/example/printer/src/lib.rs
+++ b/example/printer/src/lib.rs
@@ -15,5 +15,5 @@ limitations under the License.
 */
 
 pub trait Printer {
-    fn print(&mut self, message: &str);
+    fn print(&self, message: &str);
 }

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -14,26 +14,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-use lockjaw::{
-    component, component_module_manifest, injectable, module, module_impl, MaybeScopedMut,
-};
+use lockjaw::{component, component_module_manifest, injectable, module, module_impl, MaybeScoped};
 
 #[injectable]
 pub struct Greeter<'a> {
     #[inject]
     phrase: String,
     #[inject]
-    printer: MaybeScopedMut<'a, dyn ::printer::Printer>,
+    printer: MaybeScoped<'a, dyn ::printer::Printer>,
 }
 
 impl Greeter<'_> {
-    pub fn greet(&mut self) {
+    pub fn greet(&self) {
         self.printer.print(&self.phrase);
     }
 }
-
-#[injectable(scope = "crate::MyComponent")]
-pub struct Foo {}
 
 #[module]
 struct MyModule {}
@@ -51,12 +46,11 @@ pub struct ModuleManifest(crate::MyModule, ::printer_impl::Module);
 
 #[component(modules = "crate::ModuleManifest")]
 pub trait MyComponent {
-    fn greeter(&mut self) -> crate::Greeter;
-    fn foo(&self) -> &crate::Foo;
+    fn greeter(&self) -> crate::Greeter;
 }
 
 pub fn main() {
-    let mut component = MyComponent::new();
+    let component = MyComponent::new();
 
     component.greeter().greet();
 }
@@ -68,15 +62,14 @@ pub struct TestModuleManifest(crate::MyModule, ::printer_test::Module);
 #[cfg(test)]
 #[component(modules = "crate::TestModuleManifest")]
 pub trait TestComponent {
-    fn greeter(&mut self) -> crate::Greeter;
+    fn greeter(&self) -> crate::Greeter;
 
     fn test_printer(&self) -> &::printer_test::TestPrinter;
-    fn test_printer_mut(&mut self) -> &mut ::printer_test::TestPrinter;
 }
 
 #[test]
 fn test_greeter() {
-    let mut component = TestComponent::new();
+    let component = TestComponent::new();
     component.greeter().greet();
 
     assert_eq!(

--- a/processor/protos/manifest.proto
+++ b/processor/protos/manifest.proto
@@ -67,7 +67,6 @@ message Type {
   optional bool trait_object = 5;
   optional bool ref = 6;
   repeated Type scopes = 7;
-  optional bool mut = 8;
 }
 
 message Module {

--- a/processor/src/lib.rs
+++ b/processor/src/lib.rs
@@ -155,32 +155,24 @@ struct EpilogueConfig {
 #[proc_macro]
 pub fn private_root_epilogue(input: TokenStream) -> TokenStream {
     handle_error(|| {
+        let set: HashSet<String> = input.into_iter().map(|t| t.to_string()).collect();
         let config = EpilogueConfig {
-            // rustdoc --test does not run with #[cfg(test)] and will reach here.
-            for_test: environment::current_crate().eq("lockjaw"),
-            ..create_epilogue_config(input)
+            debug_output: set.contains("debug_output"),
+            ..EpilogueConfig::default()
         };
         internal_epilogue(config)
     })
 }
 
 #[proc_macro]
-pub fn private_test_epilogue(input: TokenStream) -> TokenStream {
+pub fn private_test_epilogue(_input: TokenStream) -> TokenStream {
     handle_error(|| {
         let config = EpilogueConfig {
             for_test: true,
-            ..create_epilogue_config(input)
+            ..EpilogueConfig::default()
         };
         internal_epilogue(config)
     })
-}
-
-fn create_epilogue_config(input: TokenStream) -> EpilogueConfig {
-    let set: HashSet<String> = input.into_iter().map(|t| t.to_string()).collect();
-    EpilogueConfig {
-        debug_output: set.contains("debug_output"),
-        ..EpilogueConfig::default()
-    }
 }
 
 fn internal_epilogue(
@@ -240,6 +232,10 @@ fn internal_epilogue(
             #components
             #path_test
         };
+
+        if config.for_test {
+            return Ok(result);
+        }
 
         if config.debug_output {
             let mut content = format!("/* manifest:\n{:#?}\n*/\n", merged_manifest);

--- a/processor/src/manifests.rs
+++ b/processor/src/manifests.rs
@@ -38,7 +38,6 @@ lazy_static! {
         m.insert("String".into(), "std::string::String".into());
         m.insert("Vec".into(), "std::vec::Vec".into());
         m.insert("MaybeScoped".into(),"lockjaw::MaybeScoped".into() );
-        m.insert("MaybeScopedMut".into(),"lockjaw::MaybeScopedMut".into() );
         m
     };
 }
@@ -116,9 +115,6 @@ impl Type {
         if self.get_field_ref() {
             prefix.push_str("ref_");
         }
-        if self.get_field_mut() {
-            prefix.push_str("mut_");
-        }
         quote::format_ident!(
             "{}{}",
             prefix,
@@ -135,9 +131,6 @@ impl Type {
         let mut prefix = String::new();
         if self.get_field_ref() {
             prefix.push_str("ref ");
-        }
-        if self.get_field_mut() {
-            prefix.push_str("mut ");
         }
         format!("{}{}", prefix, self.canonical_string_path())
     }
@@ -175,9 +168,6 @@ pub fn type_from_syn_type(syn_type: &syn::Type) -> Result<Type, TokenStream> {
         syn::Type::Reference(ref reference) => {
             let mut t: Type = type_from_syn_type(reference.elem.deref())?;
             t.set_field_ref(true);
-            if reference.mutability.is_some() {
-                t.set_field_mut(true);
-            }
             return Ok(t);
         }
         _ => {

--- a/processor/src/protos/manifest.rs
+++ b/processor/src/protos/manifest.rs
@@ -1705,7 +1705,6 @@ pub struct Type {
     trait_object: ::std::option::Option<bool>,
     field_ref: ::std::option::Option<bool>,
     pub scopes: ::protobuf::RepeatedField<Type>,
-    field_mut: ::std::option::Option<bool>,
     // special fields
     pub unknown_fields: ::protobuf::UnknownFields,
     pub cached_size: ::protobuf::CachedSize,
@@ -1900,25 +1899,6 @@ impl Type {
     pub fn take_scopes(&mut self) -> ::protobuf::RepeatedField<Type> {
         ::std::mem::replace(&mut self.scopes, ::protobuf::RepeatedField::new())
     }
-
-    // optional bool mut = 8;
-
-
-    pub fn get_field_mut(&self) -> bool {
-        self.field_mut.unwrap_or(false)
-    }
-    pub fn clear_field_mut(&mut self) {
-        self.field_mut = ::std::option::Option::None;
-    }
-
-    pub fn has_field_mut(&self) -> bool {
-        self.field_mut.is_some()
-    }
-
-    // Param is passed by value, moved
-    pub fn set_field_mut(&mut self, v: bool) {
-        self.field_mut = ::std::option::Option::Some(v);
-    }
 }
 
 impl ::protobuf::Message for Type {
@@ -1969,13 +1949,6 @@ impl ::protobuf::Message for Type {
                 7 => {
                     ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.scopes)?;
                 },
-                8 => {
-                    if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
-                    }
-                    let tmp = is.read_bool()?;
-                    self.field_mut = ::std::option::Option::Some(tmp);
-                },
                 _ => {
                     ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
                 },
@@ -2011,9 +1984,6 @@ impl ::protobuf::Message for Type {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
         };
-        if let Some(v) = self.field_mut {
-            my_size += 2;
-        }
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
         my_size
@@ -2045,9 +2015,6 @@ impl ::protobuf::Message for Type {
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
         };
-        if let Some(v) = self.field_mut {
-            os.write_bool(8, v)?;
-        }
         os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
@@ -2121,11 +2088,6 @@ impl ::protobuf::Message for Type {
                 |m: &Type| { &m.scopes },
                 |m: &mut Type| { &mut m.scopes },
             ));
-            fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
-                "mut",
-                |m: &Type| { &m.field_mut },
-                |m: &mut Type| { &mut m.field_mut },
-            ));
             ::protobuf::reflect::MessageDescriptor::new_pb_name::<Type>(
                 "Type",
                 fields,
@@ -2149,7 +2111,6 @@ impl ::protobuf::Clear for Type {
         self.trait_object = ::std::option::Option::None;
         self.field_ref = ::std::option::Option::None;
         self.scopes.clear();
-        self.field_mut = ::std::option::Option::None;
         self.unknown_fields.clear();
     }
 }
@@ -2818,21 +2779,21 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     \x20\x03(\x0b2\x0b.DependencyR\x0ebuilderModules\x12\x1f\n\x07modules\
     \x18\x03\x20\x03(\x0b2\x05.TypeR\x07modules\";\n\nDependency\x12\x12\n\
     \x04name\x18\x01\x20\x01(\tR\x04name\x12\x19\n\x04type\x18\x02\x20\x01(\
-    \x0b2\x05.TypeR\x04type\"\x90\x02\n\x04Type\x12\x1e\n\x04root\x18\x01\
+    \x0b2\x05.TypeR\x04type\"\xfe\x01\n\x04Type\x12\x1e\n\x04root\x18\x01\
     \x20\x01(\x0e2\n.Type.RootR\x04root\x12\x12\n\x04path\x18\x02\x20\x01(\t\
     R\x04path\x12\x14\n\x05crate\x18\x03\x20\x01(\tR\x05crate\x12\x19\n\x04a\
     rgs\x18\x04\x20\x03(\x0b2\x05.TypeR\x04args\x12!\n\x0ctrait_object\x18\
     \x05\x20\x01(\x08R\x0btraitObject\x12\x10\n\x03ref\x18\x06\x20\x01(\x08R\
-    \x03ref\x12\x1d\n\x06scopes\x18\x07\x20\x03(\x0b2\x05.TypeR\x06scopes\
-    \x12\x10\n\x03mut\x18\x08\x20\x01(\x08R\x03mut\"=\n\x04Root\x12\x0f\n\
-    \x0bUNSPECIFIED\x10\0\x12\n\n\x06GLOBAL\x10\x01\x12\t\n\x05CRATE\x10\x02\
-    \x12\r\n\tPRIMITIVE\x10\x03\"L\n\x06Module\x12\x19\n\x04type\x18\x01\x20\
-    \x01(\x0b2\x05.TypeR\x04type\x12'\n\tproviders\x18\x02\x20\x03(\x0b2\t.P\
-    roviderR\tproviders\"\x9e\x01\n\x08Provider\x12\x12\n\x04name\x18\x01\
-    \x20\x01(\tR\x04name\x12\x19\n\x04type\x18\x02\x20\x01(\x0b2\x05.TypeR\
-    \x04type\x12/\n\x0cdependencies\x18\x03\x20\x03(\x0b2\x0b.DependencyR\
-    \x0cdependencies\x12\x1c\n\x06static\x18\x04\x20\x01(\x08:\x04trueR\x06s\
-    tatic\x12\x14\n\x05binds\x18\x05\x20\x01(\x08R\x05binds\
+    \x03ref\x12\x1d\n\x06scopes\x18\x07\x20\x03(\x0b2\x05.TypeR\x06scopes\"=\
+    \n\x04Root\x12\x0f\n\x0bUNSPECIFIED\x10\0\x12\n\n\x06GLOBAL\x10\x01\x12\
+    \t\n\x05CRATE\x10\x02\x12\r\n\tPRIMITIVE\x10\x03\"L\n\x06Module\x12\x19\
+    \n\x04type\x18\x01\x20\x01(\x0b2\x05.TypeR\x04type\x12'\n\tproviders\x18\
+    \x02\x20\x03(\x0b2\t.ProviderR\tproviders\"\x9e\x01\n\x08Provider\x12\
+    \x12\n\x04name\x18\x01\x20\x01(\tR\x04name\x12\x19\n\x04type\x18\x02\x20\
+    \x01(\x0b2\x05.TypeR\x04type\x12/\n\x0cdependencies\x18\x03\x20\x03(\x0b\
+    2\x0b.DependencyR\x0cdependencies\x12\x1c\n\x06static\x18\x04\x20\x01(\
+    \x08:\x04trueR\x06static\x12\x14\n\x05binds\x18\x05\x20\x01(\x08R\x05bin\
+    ds\
 ";
 
 static file_descriptor_proto_lazy: ::protobuf::rt::LazyV2<::protobuf::descriptor::FileDescriptorProto> = ::protobuf::rt::LazyV2::INIT;


### PR DESCRIPTION
This reverts commit 44663fc0

turns out this creates a bunch of simultaneous mut reference to the component everywhere, and is painful to handle. It is easier to let each class use internal mutability instead.