### PR TITLE
Replace field injection with constructor injection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,20 @@ Example:
 ```rust
 use lockjaw::*;
 use std::ops::Add;
+
+struct GreetCounter{
+    counter : ::std::cell::RefCell<i32>
+}
+
 // Allow GreetCounter to be created in the dependency graph. These bindings are available anywhere.
 #[injectable]
-struct GreetCounter{
-    // Auto initialize with Default::default()
-    counter : ::std::cell::RefCell<i32>
+impl GreetCounter {
+    // Marks a method as the inject constructor. Lockjaw will call this to create the object.
+    #[inject]
+    pub fn new() -> Self {
+        Self{counter : std::cell::RefCell::new(0) }
+    }
+    
 }
 
 impl GreetCounter{
@@ -68,14 +77,21 @@ pub trait Greeter {
     fn greet(&self) -> String;
 }
 
-#[injectable]
 struct GreeterImpl {
-    // Initialize with an instance of GreetCounter
-    #[inject]
     greet_counter : crate::GreetCounter,
-    // Initialize with an instance of String
-    #[inject]
     phrase : String
+}
+
+#[injectable]
+impl GreeterImpl {
+    // Lockjaw will call this with other injectable objects provided.
+    #[inject]
+    pub fn new(greet_counter : crate::GreetCounter, phrase : String) -> Self {
+        Self {
+            greet_counter,
+            phrase
+        }
+    }
 }
 
 impl Greeter for GreeterImpl{

--- a/example/printer/printer_impl/src/lib.rs
+++ b/example/printer/printer_impl/src/lib.rs
@@ -17,8 +17,15 @@ limitations under the License.
 use lockjaw::{epilogue, injectable, module, module_impl};
 use printer::Printer;
 
-#[injectable]
 pub struct PrinterImpl {}
+
+#[injectable]
+impl PrinterImpl {
+    #[inject]
+    pub fn new() -> Self {
+        PrinterImpl {}
+    }
+}
 
 impl Printer for PrinterImpl {
     fn print(&self, message: &str) {

--- a/example/printer/printer_test/src/lib.rs
+++ b/example/printer/printer_test/src/lib.rs
@@ -16,14 +16,20 @@ limitations under the License.
 
 use lockjaw::{epilogue, injectable, module, module_impl};
 use printer::Printer;
-use std::cell::Ref;
+use std::cell::{Ref, RefCell};
 
-#[injectable(scope = "::example::TestComponent")]
 pub struct TestPrinter {
     pub messages: ::std::cell::RefCell<Vec<String>>,
 }
-
+#[injectable(scope = "::example::TestComponent")]
 impl TestPrinter {
+    #[inject]
+    pub fn new() -> TestPrinter {
+        TestPrinter {
+            messages: RefCell::default(),
+        }
+    }
+
     pub fn get_messages(&self) -> Ref<Vec<String>> {
         self.messages.borrow()
     }

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -16,15 +16,20 @@ limitations under the License.
 
 use lockjaw::{component, component_module_manifest, injectable, module, module_impl, MaybeScoped};
 
-#[injectable]
 pub struct Greeter<'a> {
-    #[inject]
     phrase: String,
-    #[inject]
     printer: MaybeScoped<'a, dyn ::printer::Printer>,
 }
 
+#[injectable]
 impl Greeter<'_> {
+    #[inject]
+    pub fn new<'a>(
+        phrase: String,
+        printer: MaybeScoped<'a, dyn ::printer::Printer>,
+    ) -> Greeter<'a> {
+        Greeter { phrase, printer }
+    }
     pub fn greet(&self) {
         self.printer.print(&self.phrase);
     }

--- a/processor/protos/manifest.proto
+++ b/processor/protos/manifest.proto
@@ -25,9 +25,9 @@ message Manifest {
 }
 
 message Injectable {
-  optional string crate = 1;
-  optional Type type = 2;
-  repeated Field fields = 3;
+  optional Type type = 1;
+  optional string ctor_name = 2;
+  repeated Dependency dependencies = 4;
 }
 
 message Field {

--- a/processor/src/manifests.rs
+++ b/processor/src/manifests.rs
@@ -123,6 +123,7 @@ impl Type {
                 .replace("<", "_L_")
                 .replace(">", "_R_")
                 .replace(" ", "_")
+                .replace("\'", "")
         )
     }
 

--- a/processor/src/parsing.rs
+++ b/processor/src/parsing.rs
@@ -40,6 +40,10 @@ pub fn is_attribute(syn_attr: &syn::Attribute, attr: &str) -> bool {
     }
 }
 
+pub fn has_attribute(attrs: &Vec<syn::Attribute>, attr: &str) -> bool {
+    attrs.iter().find(|a| is_attribute(a, attr)).is_some()
+}
+
 pub fn get_parenthesized_attribute_metadata(
     attr: TokenStream,
 ) -> Result<HashMap<String, String>, TokenStream> {

--- a/processor/src/protos/manifest.rs
+++ b/processor/src/protos/manifest.rs
@@ -380,9 +380,9 @@ impl ::protobuf::reflect::ProtobufValue for Manifest {
 #[derive(PartialEq,Clone,Default)]
 pub struct Injectable {
     // message fields
-    field_crate: ::protobuf::SingularField<::std::string::String>,
     pub field_type: ::protobuf::SingularPtrField<Type>,
-    pub fields: ::protobuf::RepeatedField<Field>,
+    ctor_name: ::protobuf::SingularField<::std::string::String>,
+    pub dependencies: ::protobuf::RepeatedField<Dependency>,
     // special fields
     pub unknown_fields: ::protobuf::UnknownFields,
     pub cached_size: ::protobuf::CachedSize,
@@ -399,43 +399,7 @@ impl Injectable {
         ::std::default::Default::default()
     }
 
-    // optional string crate = 1;
-
-
-    pub fn get_field_crate(&self) -> &str {
-        match self.field_crate.as_ref() {
-            Some(v) => &v,
-            None => "",
-        }
-    }
-    pub fn clear_field_crate(&mut self) {
-        self.field_crate.clear();
-    }
-
-    pub fn has_field_crate(&self) -> bool {
-        self.field_crate.is_some()
-    }
-
-    // Param is passed by value, moved
-    pub fn set_field_crate(&mut self, v: ::std::string::String) {
-        self.field_crate = ::protobuf::SingularField::some(v);
-    }
-
-    // Mutable pointer to the field.
-    // If field is not initialized, it is initialized with default value first.
-    pub fn mut_field_crate(&mut self) -> &mut ::std::string::String {
-        if self.field_crate.is_none() {
-            self.field_crate.set_default();
-        }
-        self.field_crate.as_mut().unwrap()
-    }
-
-    // Take field
-    pub fn take_field_crate(&mut self) -> ::std::string::String {
-        self.field_crate.take().unwrap_or_else(|| ::std::string::String::new())
-    }
-
-    // optional .Type type = 2;
+    // optional .Type type = 1;
 
 
     pub fn get_field_type(&self) -> &Type {
@@ -468,29 +432,65 @@ impl Injectable {
         self.field_type.take().unwrap_or_else(|| Type::new())
     }
 
-    // repeated .Field fields = 3;
+    // optional string ctor_name = 2;
 
 
-    pub fn get_fields(&self) -> &[Field] {
-        &self.fields
+    pub fn get_ctor_name(&self) -> &str {
+        match self.ctor_name.as_ref() {
+            Some(v) => &v,
+            None => "",
+        }
     }
-    pub fn clear_fields(&mut self) {
-        self.fields.clear();
+    pub fn clear_ctor_name(&mut self) {
+        self.ctor_name.clear();
+    }
+
+    pub fn has_ctor_name(&self) -> bool {
+        self.ctor_name.is_some()
     }
 
     // Param is passed by value, moved
-    pub fn set_fields(&mut self, v: ::protobuf::RepeatedField<Field>) {
-        self.fields = v;
+    pub fn set_ctor_name(&mut self, v: ::std::string::String) {
+        self.ctor_name = ::protobuf::SingularField::some(v);
     }
 
     // Mutable pointer to the field.
-    pub fn mut_fields(&mut self) -> &mut ::protobuf::RepeatedField<Field> {
-        &mut self.fields
+    // If field is not initialized, it is initialized with default value first.
+    pub fn mut_ctor_name(&mut self) -> &mut ::std::string::String {
+        if self.ctor_name.is_none() {
+            self.ctor_name.set_default();
+        }
+        self.ctor_name.as_mut().unwrap()
     }
 
     // Take field
-    pub fn take_fields(&mut self) -> ::protobuf::RepeatedField<Field> {
-        ::std::mem::replace(&mut self.fields, ::protobuf::RepeatedField::new())
+    pub fn take_ctor_name(&mut self) -> ::std::string::String {
+        self.ctor_name.take().unwrap_or_else(|| ::std::string::String::new())
+    }
+
+    // repeated .Dependency dependencies = 4;
+
+
+    pub fn get_dependencies(&self) -> &[Dependency] {
+        &self.dependencies
+    }
+    pub fn clear_dependencies(&mut self) {
+        self.dependencies.clear();
+    }
+
+    // Param is passed by value, moved
+    pub fn set_dependencies(&mut self, v: ::protobuf::RepeatedField<Dependency>) {
+        self.dependencies = v;
+    }
+
+    // Mutable pointer to the field.
+    pub fn mut_dependencies(&mut self) -> &mut ::protobuf::RepeatedField<Dependency> {
+        &mut self.dependencies
+    }
+
+    // Take field
+    pub fn take_dependencies(&mut self) -> ::protobuf::RepeatedField<Dependency> {
+        ::std::mem::replace(&mut self.dependencies, ::protobuf::RepeatedField::new())
     }
 }
 
@@ -501,7 +501,7 @@ impl ::protobuf::Message for Injectable {
                 return false;
             }
         };
-        for v in &self.fields {
+        for v in &self.dependencies {
             if !v.is_initialized() {
                 return false;
             }
@@ -514,13 +514,13 @@ impl ::protobuf::Message for Injectable {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
-                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.field_crate)?;
-                },
-                2 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.field_type)?;
                 },
-                3 => {
-                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.fields)?;
+                2 => {
+                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.ctor_name)?;
+                },
+                4 => {
+                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.dependencies)?;
                 },
                 _ => {
                     ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
@@ -534,14 +534,14 @@ impl ::protobuf::Message for Injectable {
     #[allow(unused_variables)]
     fn compute_size(&self) -> u32 {
         let mut my_size = 0;
-        if let Some(ref v) = self.field_crate.as_ref() {
-            my_size += ::protobuf::rt::string_size(1, &v);
-        }
         if let Some(ref v) = self.field_type.as_ref() {
             let len = v.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
         }
-        for value in &self.fields {
+        if let Some(ref v) = self.ctor_name.as_ref() {
+            my_size += ::protobuf::rt::string_size(2, &v);
+        }
+        for value in &self.dependencies {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
         };
@@ -551,16 +551,16 @@ impl ::protobuf::Message for Injectable {
     }
 
     fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
-        if let Some(ref v) = self.field_crate.as_ref() {
-            os.write_string(1, &v)?;
-        }
         if let Some(ref v) = self.field_type.as_ref() {
-            os.write_tag(2, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+            os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
         }
-        for v in &self.fields {
-            os.write_tag(3, ::protobuf::wire_format::WireTypeLengthDelimited)?;
+        if let Some(ref v) = self.ctor_name.as_ref() {
+            os.write_string(2, &v)?;
+        }
+        for v in &self.dependencies {
+            os.write_tag(4, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
         };
@@ -602,20 +602,20 @@ impl ::protobuf::Message for Injectable {
         static descriptor: ::protobuf::rt::LazyV2<::protobuf::reflect::MessageDescriptor> = ::protobuf::rt::LazyV2::INIT;
         descriptor.get(|| {
             let mut fields = ::std::vec::Vec::new();
-            fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                "crate",
-                |m: &Injectable| { &m.field_crate },
-                |m: &mut Injectable| { &mut m.field_crate },
-            ));
             fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Type>>(
                 "type",
                 |m: &Injectable| { &m.field_type },
                 |m: &mut Injectable| { &mut m.field_type },
             ));
-            fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Field>>(
-                "fields",
-                |m: &Injectable| { &m.fields },
-                |m: &mut Injectable| { &mut m.fields },
+            fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
+                "ctor_name",
+                |m: &Injectable| { &m.ctor_name },
+                |m: &mut Injectable| { &mut m.ctor_name },
+            ));
+            fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Dependency>>(
+                "dependencies",
+                |m: &Injectable| { &m.dependencies },
+                |m: &mut Injectable| { &mut m.dependencies },
             ));
             ::protobuf::reflect::MessageDescriptor::new_pb_name::<Injectable>(
                 "Injectable",
@@ -633,9 +633,9 @@ impl ::protobuf::Message for Injectable {
 
 impl ::protobuf::Clear for Injectable {
     fn clear(&mut self) {
-        self.field_crate.clear();
         self.field_type.clear();
-        self.fields.clear();
+        self.ctor_name.clear();
+        self.dependencies.clear();
         self.unknown_fields.clear();
     }
 }
@@ -2765,35 +2765,35 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     \x02\x20\x03(\x0b2\n.ComponentR\ncomponents\x12#\n\rmerged_crates\x18\
     \x03\x20\x03(\tR\x0cmergedCrates\x12!\n\x07modules\x18\x04\x20\x03(\x0b2\
     \x07.ModuleR\x07modules\x12V\n\x1acomponent_module_manifests\x18\x05\x20\
-    \x03(\x0b2\x18.ComponentModuleManifestR\x18componentModuleManifests\"]\n\
-    \nInjectable\x12\x14\n\x05crate\x18\x01\x20\x01(\tR\x05crate\x12\x19\n\
-    \x04type\x18\x02\x20\x01(\x0b2\x05.TypeR\x04type\x12\x1e\n\x06fields\x18\
-    \x03\x20\x03(\x0b2\x06.FieldR\x06fields\"R\n\x05Field\x12\x12\n\x04name\
-    \x18\x01\x20\x01(\tR\x04name\x12\x19\n\x04type\x18\x02\x20\x01(\x0b2\x05\
-    .TypeR\x04type\x12\x1a\n\x08injected\x18\x03\x20\x01(\x08R\x08injected\"\
-    \x83\x01\n\tComponent\x12\x19\n\x04type\x18\x01\x20\x01(\x0b2\x05.TypeR\
-    \x04type\x12+\n\nprovisions\x18\x02\x20\x03(\x0b2\x0b.DependencyR\nprovi\
-    sions\x12.\n\x0fmodule_manifest\x18\x03\x20\x01(\x0b2\x05.TypeR\x0emodul\
-    eManifest\"\x8b\x01\n\x17ComponentModuleManifest\x12\x19\n\x04type\x18\
-    \x01\x20\x01(\x0b2\x05.TypeR\x04type\x124\n\x0fbuilder_modules\x18\x02\
-    \x20\x03(\x0b2\x0b.DependencyR\x0ebuilderModules\x12\x1f\n\x07modules\
-    \x18\x03\x20\x03(\x0b2\x05.TypeR\x07modules\";\n\nDependency\x12\x12\n\
-    \x04name\x18\x01\x20\x01(\tR\x04name\x12\x19\n\x04type\x18\x02\x20\x01(\
-    \x0b2\x05.TypeR\x04type\"\xfe\x01\n\x04Type\x12\x1e\n\x04root\x18\x01\
-    \x20\x01(\x0e2\n.Type.RootR\x04root\x12\x12\n\x04path\x18\x02\x20\x01(\t\
-    R\x04path\x12\x14\n\x05crate\x18\x03\x20\x01(\tR\x05crate\x12\x19\n\x04a\
-    rgs\x18\x04\x20\x03(\x0b2\x05.TypeR\x04args\x12!\n\x0ctrait_object\x18\
-    \x05\x20\x01(\x08R\x0btraitObject\x12\x10\n\x03ref\x18\x06\x20\x01(\x08R\
-    \x03ref\x12\x1d\n\x06scopes\x18\x07\x20\x03(\x0b2\x05.TypeR\x06scopes\"=\
-    \n\x04Root\x12\x0f\n\x0bUNSPECIFIED\x10\0\x12\n\n\x06GLOBAL\x10\x01\x12\
-    \t\n\x05CRATE\x10\x02\x12\r\n\tPRIMITIVE\x10\x03\"L\n\x06Module\x12\x19\
-    \n\x04type\x18\x01\x20\x01(\x0b2\x05.TypeR\x04type\x12'\n\tproviders\x18\
-    \x02\x20\x03(\x0b2\t.ProviderR\tproviders\"\x9e\x01\n\x08Provider\x12\
-    \x12\n\x04name\x18\x01\x20\x01(\tR\x04name\x12\x19\n\x04type\x18\x02\x20\
-    \x01(\x0b2\x05.TypeR\x04type\x12/\n\x0cdependencies\x18\x03\x20\x03(\x0b\
-    2\x0b.DependencyR\x0cdependencies\x12\x1c\n\x06static\x18\x04\x20\x01(\
-    \x08:\x04trueR\x06static\x12\x14\n\x05binds\x18\x05\x20\x01(\x08R\x05bin\
-    ds\
+    \x03(\x0b2\x18.ComponentModuleManifestR\x18componentModuleManifests\"u\n\
+    \nInjectable\x12\x19\n\x04type\x18\x01\x20\x01(\x0b2\x05.TypeR\x04type\
+    \x12\x1b\n\tctor_name\x18\x02\x20\x01(\tR\x08ctorName\x12/\n\x0cdependen\
+    cies\x18\x04\x20\x03(\x0b2\x0b.DependencyR\x0cdependencies\"R\n\x05Field\
+    \x12\x12\n\x04name\x18\x01\x20\x01(\tR\x04name\x12\x19\n\x04type\x18\x02\
+    \x20\x01(\x0b2\x05.TypeR\x04type\x12\x1a\n\x08injected\x18\x03\x20\x01(\
+    \x08R\x08injected\"\x83\x01\n\tComponent\x12\x19\n\x04type\x18\x01\x20\
+    \x01(\x0b2\x05.TypeR\x04type\x12+\n\nprovisions\x18\x02\x20\x03(\x0b2\
+    \x0b.DependencyR\nprovisions\x12.\n\x0fmodule_manifest\x18\x03\x20\x01(\
+    \x0b2\x05.TypeR\x0emoduleManifest\"\x8b\x01\n\x17ComponentModuleManifest\
+    \x12\x19\n\x04type\x18\x01\x20\x01(\x0b2\x05.TypeR\x04type\x124\n\x0fbui\
+    lder_modules\x18\x02\x20\x03(\x0b2\x0b.DependencyR\x0ebuilderModules\x12\
+    \x1f\n\x07modules\x18\x03\x20\x03(\x0b2\x05.TypeR\x07modules\";\n\nDepen\
+    dency\x12\x12\n\x04name\x18\x01\x20\x01(\tR\x04name\x12\x19\n\x04type\
+    \x18\x02\x20\x01(\x0b2\x05.TypeR\x04type\"\xfe\x01\n\x04Type\x12\x1e\n\
+    \x04root\x18\x01\x20\x01(\x0e2\n.Type.RootR\x04root\x12\x12\n\x04path\
+    \x18\x02\x20\x01(\tR\x04path\x12\x14\n\x05crate\x18\x03\x20\x01(\tR\x05c\
+    rate\x12\x19\n\x04args\x18\x04\x20\x03(\x0b2\x05.TypeR\x04args\x12!\n\
+    \x0ctrait_object\x18\x05\x20\x01(\x08R\x0btraitObject\x12\x10\n\x03ref\
+    \x18\x06\x20\x01(\x08R\x03ref\x12\x1d\n\x06scopes\x18\x07\x20\x03(\x0b2\
+    \x05.TypeR\x06scopes\"=\n\x04Root\x12\x0f\n\x0bUNSPECIFIED\x10\0\x12\n\n\
+    \x06GLOBAL\x10\x01\x12\t\n\x05CRATE\x10\x02\x12\r\n\tPRIMITIVE\x10\x03\"\
+    L\n\x06Module\x12\x19\n\x04type\x18\x01\x20\x01(\x0b2\x05.TypeR\x04type\
+    \x12'\n\tproviders\x18\x02\x20\x03(\x0b2\t.ProviderR\tproviders\"\x9e\
+    \x01\n\x08Provider\x12\x12\n\x04name\x18\x01\x20\x01(\tR\x04name\x12\x19\
+    \n\x04type\x18\x02\x20\x01(\x0b2\x05.TypeR\x04type\x12/\n\x0cdependencie\
+    s\x18\x03\x20\x03(\x0b2\x0b.DependencyR\x0cdependencies\x12\x1c\n\x06sta\
+    tic\x18\x04\x20\x01(\x08:\x04trueR\x06static\x12\x14\n\x05binds\x18\x05\
+    \x20\x01(\x08R\x05binds\
 ";
 
 static file_descriptor_proto_lazy: ::protobuf::rt::LazyV2<::protobuf::descriptor::FileDescriptorProto> = ::protobuf::rt::LazyV2::INIT;

--- a/src/doctests/component.rs
+++ b/src/doctests/component.rs
@@ -89,8 +89,15 @@ mod component_trait_object_provision_no_lifetime {}
 ///
 /// use lockjaw::{component, injectable, epilogue};
 ///
-/// #[injectable(scope = "crate::MyComponent")]
 /// pub struct Foo {}
+///
+/// #[injectable(scope = "crate::MyComponent")]
+/// impl Foo{
+///     #[inject]
+///     pub fn new() -> Self {
+///         Self {}
+///     }
+/// }
 ///
 /// #[component]
 /// pub trait MyComponent {

--- a/src/doctests/graph.rs
+++ b/src/doctests/graph.rs
@@ -32,16 +32,28 @@ mod graph_missing_binding {}
 /// ```compile_fail
 /// #[macro_use] extern crate lockjaw_processor;
 ///
-/// #[injectable]
 /// struct Foo{
-///     #[inject]
 ///     bar: Box<crate::Bar>
+/// }
+/// #[injectable]
+/// impl Foo{
+///     #[inject]
+///     pub fn new(bar: Box<crate::Bar>) -> Self {
+///         Self { bar }
+///     }
 /// }
 ///
 /// #[injectable]
 /// struct Bar{
-///     #[inject]
 ///     foo: Box<crate::Foo>
+/// }
+///
+/// #[injectable]
+/// impl Bar{
+///     #[inject]
+///     pub fn new(foo: Box<crate::Foo>) -> Self {
+///         Self {foo}
+///     }
 /// }
 ///
 /// #[component]
@@ -58,8 +70,14 @@ mod graph_cyclic_dependency {}
 /// ```compile_fail
 /// #[macro_use] extern crate lockjaw_processor;
 ///
-/// #[injectable]
 /// struct Foo {}
+///
+/// impl Foo{
+///     #[inject]
+///     pub fn new() -> Self {
+///         Self {}
+///     }
+/// }
 ///
 /// #[module]
 /// struct M{}

--- a/src/doctests/injectable.rs
+++ b/src/doctests/injectable.rs
@@ -34,22 +34,34 @@ mod injectable_tuple {}
 /// pub struct Foo {}
 ///
 /// #[injectable]
-/// pub struct Bar {
-///     foo: crate::Foo,
-/// }
-///
-/// #[component]
-/// pub trait MyComponent {
-///     fn bar(&self) -> crate::Bar;
-/// }
-///
-/// pub fn main() {
-///     let component: Box<dyn MyComponent> = MyComponent::new();
-///     component.bar();
+/// impl Foo {
+///     pub fn new() -> Self {
+///         Self {}
+///     }
 /// }
 /// epilogue!();
 ///```
-mod injectable_no_default {}
+mod injectable_no_inject {}
+
+///```compile_fail
+/// use lockjaw::{component, injectable, epilogue};
+///
+/// pub struct Foo {}
+///
+/// #[injectable]
+/// impl Foo {
+///     #[inject]
+///     pub fn new() -> Self {
+///         Self {}
+///     }
+///     #[inject]
+///     pub fn new2() -> Self {
+///         Self {}
+///     }
+/// }
+/// epilogue!();
+///```
+mod injectable_multiple_inject {}
 
 /// ```compile_fail
 /// #[macro_use] extern crate lockjaw_processor;

--- a/tests/component_inner_mod.rs
+++ b/tests/component_inner_mod.rs
@@ -18,8 +18,15 @@ limitations under the License.
 
 use lockjaw::{epilogue, injectable};
 
-#[injectable]
 pub struct Foo {}
+
+#[injectable]
+impl Foo {
+    #[inject]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
 
 mod m {
     #[lockjaw::component(path = "m")]

--- a/tests/component_provision.rs
+++ b/tests/component_provision.rs
@@ -18,8 +18,15 @@ limitations under the License.
 
 use lockjaw::{component, epilogue, injectable};
 
-#[injectable]
 pub struct Foo {}
+
+#[injectable]
+impl Foo {
+    #[inject]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
 
 #[component]
 pub trait MyComponent {

--- a/tests/component_provision_autobox.rs
+++ b/tests/component_provision_autobox.rs
@@ -18,8 +18,15 @@ limitations under the License.
 
 use lockjaw::{component, epilogue, injectable, MaybeScoped};
 
-#[injectable]
 pub struct Foo {}
+
+#[injectable]
+impl Foo {
+    #[inject]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
 
 #[component]
 pub trait MyComponent {

--- a/tests/component_provision_indirectly_scoped.rs
+++ b/tests/component_provision_indirectly_scoped.rs
@@ -18,12 +18,19 @@ use lockjaw::{
     component, component_module_manifest, epilogue, injectable, module, module_impl, MaybeScoped,
 };
 
-#[injectable(scope = "crate::MyComponent")]
 struct GreetCounter {
     counter: ::std::cell::RefCell<i32>,
 }
 
+#[injectable(scope = "crate::MyComponent")]
 impl GreetCounter {
+    #[inject]
+    pub fn new() -> Self {
+        Self {
+            counter: Default::default(),
+        }
+    }
+
     pub fn increment(&self) -> i32 {
         let mut value = self.counter.borrow_mut();
         *value = *value + 1;
@@ -35,12 +42,17 @@ pub trait Greeter {
     fn greet(&self) -> String;
 }
 
-#[injectable]
 struct GreeterImpl<'a> {
-    #[inject]
     counter: &'a crate::GreetCounter,
-    #[inject]
     phrase: String,
+}
+
+#[injectable]
+impl GreeterImpl<'_> {
+    #[inject]
+    pub fn new(counter: &'_ crate::GreetCounter, phrase: String) -> GreeterImpl<'_> {
+        GreeterImpl { counter, phrase }
+    }
 }
 
 impl Greeter for GreeterImpl<'_> {

--- a/tests/component_provision_scoped.rs
+++ b/tests/component_provision_scoped.rs
@@ -18,8 +18,15 @@ limitations under the License.
 
 use lockjaw::{component, epilogue, injectable};
 
-#[injectable(scope = "crate::MyComponent")]
 pub struct Foo {}
+
+#[injectable(scope = "crate::MyComponent")]
+impl Foo {
+    #[inject]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
 
 #[component]
 pub trait MyComponent {

--- a/tests/injectable_inject.rs
+++ b/tests/injectable_inject.rs
@@ -18,13 +18,26 @@ limitations under the License.
 
 use lockjaw::{component, epilogue, injectable};
 
-#[injectable]
 pub struct Foo {}
 
 #[injectable]
-pub struct Bar {
+impl Foo {
     #[inject]
-    foo: crate::Foo,
+    pub fn new() -> Foo {
+        Foo {}
+    }
+}
+
+pub struct Bar {
+    foo: Foo,
+}
+
+#[injectable]
+impl Bar {
+    #[inject]
+    pub fn new(foo: crate::Foo) -> Bar {
+        Bar { foo }
+    }
 }
 
 #[component]

--- a/tests/injectable_inject_autobox.rs
+++ b/tests/injectable_inject_autobox.rs
@@ -18,13 +18,26 @@ limitations under the License.
 
 use lockjaw::{component, epilogue, injectable, MaybeScoped};
 
-#[injectable]
 pub struct Foo {}
 
 #[injectable]
-pub struct Bar<'a> {
+impl Foo {
     #[inject]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+pub struct Bar<'a> {
     foo: MaybeScoped<'a, crate::Foo>,
+}
+
+#[injectable]
+impl Bar<'_> {
+    #[inject]
+    pub fn new(foo: MaybeScoped<'_, crate::Foo>) -> Bar<'_> {
+        Bar { foo }
+    }
 }
 
 #[component]

--- a/tests/injectable_inject_extern.rs
+++ b/tests/injectable_inject_extern.rs
@@ -16,10 +16,15 @@ limitations under the License.
 use lockjaw::{component, epilogue, injectable};
 
 #[allow(dead_code)]
-#[injectable]
 pub struct Bar {
-    #[inject]
     dep: ::test_dep::DepInjectable,
+}
+#[injectable]
+impl Bar {
+    #[inject]
+    pub fn new(dep: ::test_dep::DepInjectable) -> Self {
+        Self { dep }
+    }
 }
 
 #[component]

--- a/tests/injectable_inject_scoped.rs
+++ b/tests/injectable_inject_scoped.rs
@@ -18,9 +18,18 @@ limitations under the License.
 
 use lockjaw::{component, epilogue, injectable};
 
-#[injectable(scope = "crate::MyComponent")]
 pub struct Foo {
     pub i: ::std::cell::RefCell<u32>,
+}
+
+#[injectable(scope = "crate::MyComponent")]
+impl Foo {
+    #[inject]
+    pub fn new() -> Self {
+        Self {
+            i: Default::default(),
+        }
+    }
 }
 
 impl Foo {
@@ -30,10 +39,17 @@ impl Foo {
         v
     }
 }
-#[injectable]
+
 pub struct Bar<'a> {
-    #[inject]
     foo: &'a crate::Foo,
+}
+
+#[injectable]
+impl Bar<'_> {
+    #[inject]
+    pub fn new(foo: &'_ crate::Foo) -> Bar<'_> {
+        Bar { foo }
+    }
 }
 
 #[component]

--- a/tests/injectable_inner_mod_path.rs
+++ b/tests/injectable_inner_mod_path.rs
@@ -19,8 +19,16 @@ limitations under the License.
 use lockjaw::{component, epilogue};
 
 mod baz {
-    #[lockjaw::injectable(path = "baz")]
+
     pub struct Foo {}
+
+    #[lockjaw::injectable(path = "baz")]
+    impl Foo {
+        #[inject]
+        pub fn new() -> Self {
+            Self {}
+        }
+    }
 }
 #[component]
 pub trait MyComponent {

--- a/tests/injectable_inner_mod_path_outer_impl.rs
+++ b/tests/injectable_inner_mod_path_outer_impl.rs
@@ -16,20 +16,27 @@ limitations under the License.
 
 #![allow(dead_code)]
 
-use lockjaw::{component, epilogue, injectable};
+use lockjaw::{component, epilogue};
 
-#[injectable]
-pub struct Foo {
-    i: i32,
+mod baz {
+    pub struct Foo {}
+}
+
+#[lockjaw::injectable]
+impl baz::Foo {
+    #[inject]
+    pub fn new() -> Self {
+        Self {}
+    }
 }
 
 #[component]
 pub trait MyComponent {
-    fn foo(&self) -> crate::Foo;
+    fn foo(&self) -> crate::baz::Foo;
 }
 #[test]
 pub fn main() {
     let component: Box<dyn MyComponent> = MyComponent::new();
-    assert_eq!(component.foo().i, 0);
+    component.foo();
 }
 epilogue!();

--- a/tests/injectable_scoped.rs
+++ b/tests/injectable_scoped.rs
@@ -18,12 +18,19 @@ limitations under the License.
 
 use lockjaw::{component, epilogue, injectable};
 
-#[injectable(scope = "crate::MyComponent")]
 pub struct Foo {
     pub i: ::std::cell::RefCell<u32>,
 }
 
+#[injectable(scope = "crate::MyComponent")]
 impl Foo {
+    #[inject]
+    pub fn new() -> Self {
+        Self {
+            i: Default::default(),
+        }
+    }
+
     pub fn count(&self) -> u32 {
         let v: u32 = self.i.borrow().clone();
         self.i.replace(v + 1);

--- a/tests/module_bind_indireclty_maybe_scoped_trait.rs
+++ b/tests/module_bind_indireclty_maybe_scoped_trait.rs
@@ -20,17 +20,30 @@ use lockjaw::{
     component, component_module_manifest, epilogue, injectable, module, module_impl, MaybeScoped,
 };
 
-#[injectable(scope = "crate::MyComponent")]
 pub struct Foo {}
+
+#[injectable(scope = "crate::MyComponent")]
+impl Foo {
+    #[inject]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
 
 pub trait MyTrait {
     fn hello(&self) -> String;
 }
 
-#[injectable]
 pub struct MyTraitImpl<'a> {
-    #[inject]
     foo: MaybeScoped<'a, crate::Foo>,
+}
+
+#[injectable]
+impl MyTraitImpl<'_> {
+    #[inject]
+    pub fn new(foo: MaybeScoped<'_, crate::Foo>) -> MyTraitImpl {
+        MyTraitImpl { foo }
+    }
 }
 
 impl MyTrait for MyTraitImpl<'_> {

--- a/tests/module_bind_indireclty_scoped_trait.rs
+++ b/tests/module_bind_indireclty_scoped_trait.rs
@@ -20,17 +20,30 @@ use lockjaw::{
     component, component_module_manifest, epilogue, injectable, module, module_impl, MaybeScoped,
 };
 
-#[injectable(scope = "crate::MyComponent")]
 pub struct Foo {}
+
+#[injectable(scope = "crate::MyComponent")]
+impl Foo {
+    #[inject]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
 
 pub trait MyTrait {
     fn hello(&self) -> String;
 }
 
-#[injectable]
 pub struct MyTraitImpl<'a> {
-    #[inject]
     foo: &'a crate::Foo,
+}
+
+#[injectable]
+impl MyTraitImpl<'_> {
+    #[inject]
+    pub fn new(foo: &'_ crate::Foo) -> MyTraitImpl<'_> {
+        MyTraitImpl { foo }
+    }
 }
 
 impl MyTrait for MyTraitImpl<'_> {

--- a/tests/module_bind_scoped_trait.rs
+++ b/tests/module_bind_scoped_trait.rs
@@ -26,8 +26,15 @@ pub trait MyTrait {
     fn hello(&self) -> String;
 }
 
-#[injectable(scope = "crate::MyComponent")]
 pub struct MyTraitImpl {}
+
+#[injectable(scope = "crate::MyComponent")]
+impl MyTraitImpl {
+    #[inject]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
 
 impl MyTrait for MyTraitImpl {
     fn hello(&self) -> String {

--- a/tests/module_bind_trait.rs
+++ b/tests/module_bind_trait.rs
@@ -26,8 +26,15 @@ pub trait MyTrait {
     fn hello(&self) -> String;
 }
 
-#[injectable]
 pub struct MyTraitImpl {}
+
+#[injectable]
+impl MyTraitImpl {
+    #[inject]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
 
 impl MyTrait for MyTraitImpl {
     fn hello(&self) -> String {

--- a/tests/module_inject_param.rs
+++ b/tests/module_inject_param.rs
@@ -22,8 +22,15 @@ pub struct Foo {
     bar: Bar,
 }
 
-#[injectable()]
 pub struct Bar {}
+
+#[injectable]
+impl Bar {
+    #[inject]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
 
 #[module]
 pub struct MyModule {}

--- a/tests/module_inject_param_autobox.rs
+++ b/tests/module_inject_param_autobox.rs
@@ -24,8 +24,15 @@ pub struct Foo<'a> {
     bar: MaybeScoped<'a, Bar>,
 }
 
-#[injectable()]
 pub struct Bar {}
+
+#[injectable]
+impl Bar {
+    #[inject]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
 
 #[module]
 pub struct MyModule {}

--- a/tests/module_inject_param_scoped.rs
+++ b/tests/module_inject_param_scoped.rs
@@ -22,9 +22,18 @@ pub struct Foo {
     i: i32,
 }
 
-#[injectable(scope = "crate::MyComponent")]
 pub struct Bar {
     i: i32,
+}
+
+#[injectable(scope = "crate::MyComponent")]
+impl Bar {
+    #[inject]
+    pub fn new() -> Self {
+        Self {
+            i: Default::default(),
+        }
+    }
 }
 
 #[module]

--- a/tests/other_file/mod.rs
+++ b/tests/other_file/mod.rs
@@ -13,9 +13,16 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-#[lockjaw::injectable]
 #[allow(dead_code)]
 pub struct InjectableFromOtherFile {}
+
+#[lockjaw::injectable]
+impl InjectableFromOtherFile {
+    #[inject]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
 
 #[lockjaw::component]
 pub trait OtherComponent {

--- a/tests/test_dep/src/lib.rs
+++ b/tests/test_dep/src/lib.rs
@@ -15,8 +15,15 @@ limitations under the License.
 */
 use lockjaw;
 
-#[lockjaw::injectable]
 pub struct DepInjectable {}
+
+#[lockjaw::injectable]
+impl DepInjectable {
+    #[inject]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
 
 #[lockjaw::component]
 pub trait DepComponent {


### PR DESCRIPTION
This allows enforces more explicit object creation instead of using Default::default(), and allows more complicated logic.